### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-#This project no longer works.
+# This project no longer works.
 
-#Applefy
+# Applefy
 
 An OSX application to store Spotify playlists as MP3's that can be imported into iTunes to be matched by Apple Music.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
